### PR TITLE
fix package.json name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "System Administration",
+  "name": "system-administration",
   "version": "0.1.0",
   "description": "Open Web App for OpenMRS System Administration ",
   "repository": {


### PR DESCRIPTION
Currently `npm-install` fails to run on this repo because `Capital letters` and `spaces` are not allowed in the "name" field of package.json. This PR aims to fix this. [Link to NPM issue](https://github.com/npm/npm/issues/6860)