### PR TITLE
fix case-sensitive bug when searching for modules

### DIFF
--- a/app/js/moduleSearch/searchModulesController.js
+++ b/app/js/moduleSearch/searchModulesController.js
@@ -52,7 +52,7 @@ SearchRepoModule.controller('searchModuleCtrl', ['$scope', '$http', 'OWARoutesUt
             $scope.moduleFound = false;
             $scope.isSearching = true;
             $scope.modules = [];
-            var searchValue = $scope.searchText;
+            var searchValue = $scope.searchText.toLowerCase();
             var requestUrl = "https://addons.openmrs.org/api/v1//addon?&q=" + searchValue;
             if (searchValue) {
                 $http.get(requestUrl, {})


### PR DESCRIPTION
This PR fixes the case-sensitive bug when searching for modules
Link to Jira issue: [OWA-43](https://issues.openmrs.org/browse/OWA-43)